### PR TITLE
feat: add vue-tailwind to the list of the detectable UI frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To support a new Vue framework, please look at [detectors/frameworks.json](detec
 - [Inkline](https://inkline.io)
 - [Chakra UI Vue](https://vue.chakra-ui.com)
 - [Oruga](https://oruga.io)
+- [VueTailwind](https://www.vue-tailwind.com/)
 
 To support a new UI library, please look at [detectors/uis.json](detectors/uis.json).
 

--- a/detectors/uis.json
+++ b/detectors/uis.json
@@ -88,7 +88,6 @@
     },
     "detectors": {
       "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && el.__vue__.$oruga)).filter(Boolean).length"
-      
     }
   },
   "vue-tailwind": {
@@ -100,6 +99,6 @@
     },
     "detectors": {
       "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && (el.__vue__.$vueTailwind || (el.__vue__.$options.components.TInput !== undefined && el.__vue__.$options.components.TButton !== undefined && el.__vue__.$options.components.TModal !== undefined)))).filter(Boolean).length"
-    }
+    },
   }
 }

--- a/detectors/uis.json
+++ b/detectors/uis.json
@@ -88,6 +88,18 @@
     },
     "detectors": {
       "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && el.__vue__.$oruga)).filter(Boolean).length"
+      
+    }
+  },
+  "vue-tailwind": {
+    "metas": {
+      "slug": "vue-tailwind",
+      "name": "VueTailwind",
+      "imgPath": "/ui/vue-tailwind.svg",
+      "url": "https://www.vue-tailwind.com/"
+    },
+    "detectors": {
+      "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && (el.__vue__.$vueTailwind || el.__vue__.$options.components.TInput !== undefined))).filter(Boolean).length"
     }
   }
 }

--- a/detectors/uis.json
+++ b/detectors/uis.json
@@ -99,7 +99,7 @@
       "url": "https://www.vue-tailwind.com/"
     },
     "detectors": {
-      "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && (el.__vue__.$vueTailwind || el.__vue__.$options.components.TInput !== undefined))).filter(Boolean).length"
+      "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && (el.__vue__.$vueTailwind || (el.__vue__.$options.components.TInput !== undefined && el.__vue__.$options.components.TButton !== undefined && el.__vue__.$options.components.TModal !== undefined)))).filter(Boolean).length"
     }
   }
 }

--- a/detectors/uis.json
+++ b/detectors/uis.json
@@ -32,6 +32,17 @@
       "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && (el.__vue__.$bvModal || el.__vue__.$bvConfig || el.__vue__.$bvToast))).filter(Boolean).length"
     }
   },
+  "vue-tailwind": {
+    "metas": {
+      "slug": "vue-tailwind",
+      "name": "VueTailwind",
+      "imgPath": "/ui/vue-tailwind.svg",
+      "url": "https://www.vue-tailwind.com/"
+    },
+    "detectors": {
+      "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && (el.__vue__.$vueTailwind || (el.__vue__.$options.components.TInput !== undefined && el.__vue__.$options.components.TButton !== undefined && el.__vue__.$options.components.TModal !== undefined)))).filter(Boolean).length"
+    }
+  },
   "tailwindcss": {
     "metas": {
       "slug": "tailwind-css",
@@ -89,16 +100,5 @@
     "detectors": {
       "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && el.__vue__.$oruga)).filter(Boolean).length"
     }
-  },
-  "vue-tailwind": {
-    "metas": {
-      "slug": "vue-tailwind",
-      "name": "VueTailwind",
-      "imgPath": "/ui/vue-tailwind.svg",
-      "url": "https://www.vue-tailwind.com/"
-    },
-    "detectors": {
-      "js": "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__ && (el.__vue__.$vueTailwind || (el.__vue__.$options.components.TInput !== undefined && el.__vue__.$options.components.TButton !== undefined && el.__vue__.$options.components.TModal !== undefined)))).filter(Boolean).length"
-    },
   }
 }

--- a/icons/ui/vue-tailwind.svg
+++ b/icons/ui/vue-tailwind.svg
@@ -1,0 +1,8 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+    <g transform="matrix(0.036324,0,0,0.036324,20,14)">
+        <path id="T" d="M340.065,589L0,-0L2500.03,0.018L2159.98,589L1731.17,589L1250,1421.95L768.833,589L340.065,589Z" style="fill:rgb(237,137,54);fill-rule:nonzero;"/>
+        <g id="V" transform="matrix(-1,-1.53143e-15,-1.53143e-15,1,2500,589)">
+            <path d="M1731.17,0L1250,832.948L768.833,0L0,0L1250,2164L2500,0L1731.17,0Z" style="fill:rgb(45,55,72);fill-rule:nonzero;"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Vue-tailwind is a new set of UI components for vue powered sites, this new framework is having a growing adoption since is the only one that perfectly adapts to TailwindCSS

It's used in nuxt, gridsome and standalone Vue applications.


## Types of changes
- [x] New Detector
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Adding a new detector for the vue-tailwind UI framework (https://www.vue-tailwind.com/), this framework did not have one a flag to be detected like `__vue__.$vueTailwind` until the new version that I just released 1 minute ago for this purpose so I am looking if the page has 3 of the most representative components in the library so it works with not updated libraries.

## Checklist:
- [x] I have updated the README accordingly <!-- apply to new detector or new feature -->
- [x] I have added the icon of my detector in `icons/` <!-- apply to new detector -->
